### PR TITLE
Fixed numpy version error in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ultralytics==8.0.20
 gitpython
 ipython  # interactive notebook
 matplotlib>=3.2.2
-numpy==1.23.1
+numpy==1.21.6
 opencv-python>=4.1.1
 Pillow>=7.1.2
 psutil  # system resources


### PR DESCRIPTION
No matching distribution found for numpy==1.23.1
Changed to numpy==1.21.6 and tested. Works fine without error.