### PR TITLE
Remove un controlled bounding box printing

### DIFF
--- a/trackers/strongsort/strong_sort.py
+++ b/trackers/strongsort/strong_sort.py
@@ -50,7 +50,6 @@ class StrongSORT(object):
         self.height, self.width = ori_img.shape[:2]
         
         # generate detections
-        print(xywhs)
         features = self._get_features(xywhs, ori_img)
         bbox_tlwh = self._xywh_to_tlwh(xywhs)
         detections = [Detection(bbox_tlwh[i], conf, features[i]) for i, conf in enumerate(


### PR DESCRIPTION
removed printing of bboxes in StrongSort. It's extremely annoying when you get unexpected outputs in executing models. It's a quick fix, just removed one line of code